### PR TITLE
Convert to no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,8 @@ edition = "2018"
 travis-ci = { repository = "flosse/rust-sun", branch = "master" }
 appveyor = { repository = "flosse/rust-sun", branch = "master" }
 
+[features]
+no-std = ["num-traits"]
+
 [dependencies]
-num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+num-traits = { version = "0.2", default-features = false, features = ["libm"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2018"
 [badges]
 travis-ci = { repository = "flosse/rust-sun", branch = "master" }
 appveyor = { repository = "flosse/rust-sun", branch = "master" }
+
+[dependencies]
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 //! The `sun` crate is a library for calculating the position of the sun.
 //! It is a port of the `JavaScript` library
 //! [suncalc](https://github.com/mourner/suncalc).
@@ -14,7 +15,9 @@
 //! println!("The position of the sun is {}/{}", az, alt);
 //! ```
 
-use std::f64::consts::PI;
+use core::f64::consts::PI;
+#[allow(unused_imports)]
+use num_traits::real::Real;
 
 // date/time constants and conversions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(feature = "no-std", no_std)]
 //! The `sun` crate is a library for calculating the position of the sun.
 //! It is a port of the `JavaScript` library
 //! [suncalc](https://github.com/mourner/suncalc).
@@ -15,9 +15,15 @@
 //! println!("The position of the sun is {}/{}", az, alt);
 //! ```
 
+#[cfg(feature = "no-std")]
 use core::f64::consts::PI;
+
+#[cfg(feature = "no-std")]
 #[allow(unused_imports)]
 use num_traits::real::Real;
+
+#[cfg(not(feature = "no-std"))]
+use std::f64::consts::PI;
 
 // date/time constants and conversions
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 
 #[cfg(feature = "no-std")]
 use core::f64::consts::PI;
-
 #[cfg(feature = "no-std")]
 #[allow(unused_imports)]
 use num_traits::real::Real;


### PR DESCRIPTION
Hey :wave: 

Thanks for your work, I'm glab that I can use your lib.
My usage is in a `no-std` env so I need it to be `no-std` too.
It's a small change that you may want, feel free to merge.
(I can turn it into a `no-std` feature if you want to avoid unecessary deps.)
