### PR TITLE
Calculate times of sunset, sunrise and other sun phases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,5 +23,8 @@ pub fn main() {
   let az  = pos.azimuth.to_degrees();
   let alt = pos.altitude.to_degrees();
   println!("The position of the sun is {}/{}", az, alt);
+
+  let time_ms = sun::time_at_phase(unixtime, sun::SunPhase::Sunrise, lat, lon, 0.0);
+  println!("Sunrise is at {}", time_ms);
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
-//! The `sun` crate is a library for calculating the position of the sun.
+//! The `sun` crate is a library for calculating the position of the sun and sun phases
+//! (like sunrise, sunset).
 //! It is a port of the `JavaScript` library
 //! [suncalc](https://github.com/mourner/suncalc).
 //!
@@ -12,6 +13,10 @@
 //! let az  = pos.azimuth.to_degrees();
 //! let alt = pos.altitude.to_degrees();
 //! println!("The position of the sun is {}/{}", az, alt);
+//!
+//! // calculate time of sunrise
+//! let time_ms = sun::time_at_phase(unixtime, sun::SunPhase::Sunrise, lat, lon, 0.0);
+//! assert_eq!(time_ms, 1362463116241);
 //! ```
 
 use std::f64::consts::PI;
@@ -19,6 +24,7 @@ use std::f64::consts::PI;
 // date/time constants and conversions
 
 const MILLISECONDS_PER_DAY: u32 = 1000 * 60 * 60 * 24;
+const J0: f64 = 0.0009;
 const J1970: u32 = 2_440_588;
 const J2000: u32 = 2_451_545;
 const TO_RAD: f64 = PI / 180.0;
@@ -36,6 +42,10 @@ pub struct Position {
 
 fn to_julian(unixtime_in_ms: i64) -> f64 {
     unixtime_in_ms as f64 / (MILLISECONDS_PER_DAY as f64) - 0.5 + J1970 as f64
+}
+
+fn from_julian(j: f64) -> i64 {
+    ((j + 0.5 - J1970 as f64) * MILLISECONDS_PER_DAY as f64).round() as i64
 }
 
 fn to_days(unixtime_in_ms: i64) -> f64 {
@@ -101,6 +111,137 @@ pub fn pos(unixtime_in_ms: i64, lat: f64, lon: f64) -> Position {
     }
 }
 
+fn julian_cycle(d: f64, lw: f64) -> f64 {
+    (d - J0 - lw / (2.0 * PI)).round()
+}
+
+fn approx_transit(ht: f64, lw: f64, n: f64) -> f64 {
+    return J0 + (ht + lw) / (2.0 * PI) + n;
+}
+
+fn solar_transit_j(ds: f64, m: f64, l: f64) -> f64 {
+    return J2000 as f64 + ds + 0.0053 * m.sin() - 0.0069 * (2.0 * l).sin();
+}
+
+fn hour_angle(h: f64, phi: f64, d: f64) -> f64 {
+    ((h.sin() - phi.sin() * d.sin()) / (phi.cos() * d.cos())).acos()
+}
+
+fn observer_angle(height: f64) -> f64 {
+    -2.076 * height.sqrt() / 60.0
+}
+
+/// returns set time for the given sun altitude
+fn get_set_j(h: f64, lw: f64, phi: f64, dec: f64, n: f64, m: f64, l: f64) -> f64 {
+    let w = hour_angle(h, phi, dec);
+    let a = approx_transit(w, lw, n);
+
+    return solar_transit_j(a, m, l);
+}
+
+/// Calculates the time for the given [`SunPhase`] at a given date, height and Latitude/Longitude.
+/// The returned time is the [unix time](https://en.wikipedia.org/wiki/Unix_time) in milliseconds.
+///
+/// # Arguments
+///
+/// * `date`      - [unix time](https://en.wikipedia.org/wiki/Unix_time) in milliseconds.
+/// * `sun_phase` - [`SunPhase] to calcuate time for
+/// * `lat`       - [latitude](https://en.wikipedia.org/wiki/Latitude) in degrees.
+/// * `lon`       - [longitude](https://en.wikipedia.org/wiki/Longitude) in degrees.
+/// * `height`    - Observer height in meters above the horizon
+///
+/// # Examples
+///
+/// ```rust
+/// // calculate time of sunrise
+/// let unixtime = 1362441600000;
+/// let lat = 48.0;
+/// let lon = 9.0;
+/// let time_ms = sun::time_at_phase(unixtime, sun::SunPhase::Sunrise, lat, lon, 0.0);
+/// assert_eq!(time_ms, 1362463116241);
+/// ```
+
+pub fn time_at_phase(date: i64, sun_phase: SunPhase, lat: f64, lon: f64, height: f64) -> i64 {
+    let lw = -lon.to_radians();
+    let phi = lat.to_radians();
+
+    let dh = observer_angle(height);
+
+    let d = to_days(date);
+    let n = julian_cycle(d, lw);
+    let ds = approx_transit(0.0, lw, n);
+
+    let m = solar_mean_anomaly(ds);
+    let l = ecliptic_longitude(m);
+    let dec = declination(l, 0.0);
+
+    let j_noon = solar_transit_j(ds, m, l);
+
+    let h0 = (sun_phase.angle_deg() + dh).to_radians();
+    let j_set = get_set_j(h0, lw, phi, dec, n, m, l);
+
+    if sun_phase.is_rise() {
+        let j_rise = j_noon - (j_set - j_noon);
+        from_julian(j_rise)
+    } else {
+        from_julian(j_set)
+    }
+}
+
+/// Sun phases for use with [`time_at_phase`].
+#[derive(Clone, Copy, Debug)]
+pub enum SunPhase {
+    Sunrise,
+    Sunset,
+    SunriseEnd,
+    SunsetStart,
+    Dawn,
+    Dusk,
+    NauticalDawn,
+    NauticalDusk,
+    NightEnd,
+    Night,
+    GoldenHourEnd,
+    GoldenHour,
+    Custom(f64, bool),
+}
+
+impl SunPhase {
+    pub fn custom(angle_deg: f64, rise: bool) -> Self {
+        SunPhase::Custom(angle_deg, rise)
+    }
+
+    fn angle_deg(&self) -> f64 {
+        match self {
+            SunPhase::Sunrise | SunPhase::Sunset => -0.833,
+            SunPhase::SunriseEnd | SunPhase::SunsetStart => -0.5,
+            SunPhase::Dawn | SunPhase::Dusk => -6.0,
+            SunPhase::NauticalDawn | SunPhase::NauticalDusk => -12.0,
+            SunPhase::NightEnd | SunPhase::Night => -18.0,
+            SunPhase::GoldenHourEnd | SunPhase::GoldenHour => 6.0,
+            SunPhase::Custom(angle, _) => *angle,
+        }
+    }
+
+    fn is_rise(&self) -> bool {
+        match self {
+            SunPhase::Sunrise
+            | SunPhase::SunriseEnd
+            | SunPhase::Dawn
+            | SunPhase::NauticalDawn
+            | SunPhase::NightEnd
+            | SunPhase::GoldenHourEnd => true,
+            SunPhase::Sunset
+            | SunPhase::SunsetStart
+            | SunPhase::Dusk
+            | SunPhase::NauticalDusk
+            | SunPhase::Night
+            | SunPhase::GoldenHour => false,
+            SunPhase::Custom(_, rise) => *rise,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -116,9 +257,41 @@ mod tests {
     }
 
     #[test]
+    fn test_time_at_angle() {
+        // 2013-03-05 UTC
+        let date = 1362441600000;
+
+        assert_eq!(
+            time_at_phase(date, SunPhase::Sunrise, 50.5, 30.5, 0.0),
+            1362458096440
+        );
+        assert_eq!(
+            time_at_phase(date, SunPhase::Sunset, 50.5, 30.5, 0.0),
+            1362498417875
+        );
+
+        // equal to Dusk
+        assert_eq!(
+            time_at_phase(date, SunPhase::custom(-6.0, false), 50.5, 30.5, 0.0),
+            1362500376781
+        );
+        // equal to Dawn
+        assert_eq!(
+            time_at_phase(date, SunPhase::custom(-6.0, true), 50.5, 30.5, 0.0),
+            1362456137534
+        );
+    }
+
+    #[test]
     fn test_to_julian() {
         // 1. Jan. 2015
         assert_eq!(2457054.5, to_julian(1422748800000));
+    }
+
+    #[test]
+    fn test_from_julian() {
+        // 1. Jan. 2015
+        assert_eq!(from_julian(2457054.5), 1422748800000);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ fn get_set_j(h: f64, lw: f64, phi: f64, dec: f64, n: f64, m: f64, l: f64) -> f64
 /// # Arguments
 ///
 /// * `date`      - [unix time](https://en.wikipedia.org/wiki/Unix_time) in milliseconds.
-/// * `sun_phase` - [`SunPhase] to calcuate time for
+/// * `sun_phase` - [`SunPhase`] to calcuate time for
 /// * `lat`       - [latitude](https://en.wikipedia.org/wiki/Latitude) in degrees.
 /// * `lon`       - [longitude](https://en.wikipedia.org/wiki/Longitude) in degrees.
 /// * `height`    - Observer height in meters above the horizon
@@ -207,6 +207,13 @@ pub enum SunPhase {
 }
 
 impl SunPhase {
+    /// Create a custom sun phase
+    ///
+    /// # Arguments
+    /// * `angle_deg` - Angle in degrees of the sun above the horizon. Use negative
+    ///                 numbers for angles below the horizon.
+    /// * `rise`      - `true` when this sun phase applies to the sun rising, `false`
+    ///                 if it's setting.
     pub fn custom(angle_deg: f64, rise: bool) -> Self {
         SunPhase::Custom(angle_deg, rise)
     }


### PR DESCRIPTION
This PR adds a function to calculate the time of sun phases like sunset, sunrise at a given date. Like `sun::pos`, it is mostly ported from the `suncalc` npm-package, with exception that it only calculates the time for one phase instead of a whole bunch (seemed more efficient/suitable to me). The function returns a timestamp (in ms). 

It would be nice to add (optional) support for the `chrono` crate, so you don't have to manually convert the timestamps to something usable after every call. That would be a separate PR though and maybe even a breaking change dependening on how it's done.